### PR TITLE
Update gradle plugin to version 4.1.3 to be in "sync" with termux-app project.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.1.3'
     }
 }
 


### PR DESCRIPTION
The project termux-app currently uses gradle-plugin version 4.1.3, and termux-float uses 4.0.0. 

This version mismatch leads to slightly different build environments and the need to download different Android NDK versions (~1GB each) to build each project.

Bumping gradle plugin version from 4.0.0 to 4.1.3 avoids those different build environments (and the NDK download) and as far as I tested doesn't break the build.