### PR TITLE
Minor Float bubble fixes

### DIFF
--- a/app/src/main/java/com/termux/window/FloatingBubbleManager.java
+++ b/app/src/main/java/com/termux/window/FloatingBubbleManager.java
@@ -1,8 +1,10 @@
 package com.termux.window;
 
+import android.graphics.Outline;
 import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewOutlineProvider;
 import android.view.WindowManager;
 
 import com.termux.shared.view.ViewUtils;
@@ -57,7 +59,15 @@ public class FloatingBubbleManager {
         layoutParams.height = BUBBLE_SIZE_PX;
 
         TerminalView terminalView = getTerminalView();
-        terminalView.setBackgroundResource(R.drawable.round_button);
+        final int strokeWidth = (int) terminalView.getResources().getDimension(R.dimen.bubble_outline_stroke_width);
+        terminalView.setOutlineProvider(new ViewOutlineProvider() {
+            @SuppressWarnings("SuspiciousNameCombination")
+            @Override
+            public void getOutline(View view, Outline outline) {
+                // shrink TerminalView clipping a bit so it doesn't cut off our bubble outline
+                outline.setOval(strokeWidth, strokeWidth, view.getWidth() - strokeWidth, view.getHeight() - strokeWidth);
+            }
+        });
         terminalView.setClipToOutline(true);
 
         TermuxFloatView termuxFloatView = getTermuxFloatView();
@@ -82,6 +92,7 @@ public class FloatingBubbleManager {
 
         TerminalView terminalView = getTerminalView();
         terminalView.setBackground(mOriginalTerminalViewBackground);
+        terminalView.setOutlineProvider(null);
         terminalView.setClipToOutline(false);
 
         TermuxFloatView termuxFloatView = getTermuxFloatView();

--- a/app/src/main/java/com/termux/window/FloatingBubbleManager.java
+++ b/app/src/main/java/com/termux/window/FloatingBubbleManager.java
@@ -15,7 +15,7 @@ import com.termux.view.TerminalView;
  * to its original display.
  */
 public class FloatingBubbleManager {
-    private static final int DEFAULT_BUBBLE_SIZE_DP = 80;
+    private static final int DEFAULT_BUBBLE_SIZE_DP = 56;
 
     private TermuxFloatView mTermuxFloatView;
     private final int BUBBLE_SIZE_PX;

--- a/app/src/main/java/com/termux/window/FloatingBubbleManager.java
+++ b/app/src/main/java/com/termux/window/FloatingBubbleManager.java
@@ -5,6 +5,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
 
+import com.termux.shared.view.ViewUtils;
 import com.termux.view.TerminalView;
 
 /**
@@ -12,9 +13,10 @@ import com.termux.view.TerminalView;
  * to its original display.
  */
 public class FloatingBubbleManager {
-    private static final int BUBBLE_SIZE = 200;
+    private static final int DEFAULT_BUBBLE_SIZE_DP = 80;
 
     private TermuxFloatView mTermuxFloatView;
+    private final int BUBBLE_SIZE_PX;
 
     private boolean mIsMinimized;
 
@@ -26,9 +28,9 @@ public class FloatingBubbleManager {
     private Drawable mOriginalTerminalViewBackground;
     private Drawable mOriginalFloatViewBackground;
 
-
     public FloatingBubbleManager(TermuxFloatView termuxFloatView) {
         mTermuxFloatView = termuxFloatView;
+        BUBBLE_SIZE_PX = ViewUtils.dpToPx(mTermuxFloatView.getContext(), DEFAULT_BUBBLE_SIZE_DP);
     }
 
     public void toggleBubble() {
@@ -50,8 +52,9 @@ public class FloatingBubbleManager {
         captureOriginalLayoutValues();
 
         WindowManager.LayoutParams layoutParams = getLayoutParams();
-        layoutParams.width = BUBBLE_SIZE;
-        layoutParams.height = BUBBLE_SIZE;
+
+        layoutParams.width = BUBBLE_SIZE_PX;
+        layoutParams.height = BUBBLE_SIZE_PX;
 
         TerminalView terminalView = getTerminalView();
         terminalView.setBackgroundResource(R.drawable.round_button);

--- a/app/src/main/res/drawable/round_button.xml
+++ b/app/src/main/res/drawable/round_button.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="oval">
-            <solid android:color="@android:color/black" />
-        </shape>
-    </item>
-</selector>

--- a/app/src/main/res/drawable/round_button_with_outline.xml
+++ b/app/src/main/res/drawable/round_button_with_outline.xml
@@ -4,7 +4,7 @@
         <shape android:shape="oval">
             <solid android:color="@android:color/black" />
             <stroke android:color="@android:color/white"
-                android:width="1dp" />
+                android:width="@dimen/bubble_outline_stroke_width" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="bubble_outline_stroke_width">1dp</dimen>
+</resources>


### PR DESCRIPTION
* Fixed: Use `dp` instead of `px` so bubble size should now be consistent across devices.
* Fixed: Some change in https://github.com/termux/termux-float/commit/90f908d0a02ec37cb2593d7fb1216c09ad60780f caused the outline to be cut off when in bubble mode but now displays properly.
![](https://user-images.githubusercontent.com/6166095/131929096-a3b14725-a909-4cae-b7a2-517d16f1f96f.png)
  - Removed `round_button.xml` drawable as no longer needed
