### PR TITLE
Fixed: Bump `desugar_jdk_libs` to 2.1.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,7 +66,7 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.1.5"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.2"
 
     testImplementation "junit:junit:4.13.2"
 


### PR DESCRIPTION
- Necessary to fix this error while building Termux from source using the [local Maven repository guide](https://github.com/termux/termux-app/wiki/Termux-Libraries#forking-and-local-development):

```
1.  Dependency 'com.termux:termux-shared:0.118.0' requires desugar_jdk_libs version to be
           2.1.2 or above for :app, which is currently 1.1.5
```

- After this PR: https://github.com/termux/termux-app/pull/3619